### PR TITLE
Simplify installer and keep async for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,25 +73,13 @@ setting.
 All configuration is managed via the `config/cable.yml`file. To use Solid Cable, the `adapter` value *must be* `solid_cable`. When using Solid Cable, the other values you can set are: `connects_to`, `polling_interval`, `silence_polling`, and `keep_messages_around_for`. For example:
 
 ```yaml
-default: &default
+production:
   adapter: solid_cable
-  polling_interval: 1.second
-  keep_messages_around_for: 1.day
-
-development:
-  <<: *default
-  silence_polling: true
   connects_to:
     database:
-      writing: solid_cable_primary
-      reading: solid_cable_replica
-
-test:
-  adapter: test
-
-production:
-  <<: *default
+      writing: cable
   polling_interval: 0.1.seconds
+  keep_messages_around_for: 1.day
 ```
 
 ## License

--- a/lib/generators/solid_cable/install/install_generator.rb
+++ b/lib/generators/solid_cable/install/install_generator.rb
@@ -3,48 +3,8 @@
 class SolidCable::InstallGenerator < Rails::Generators::Base
   source_root File.expand_path("templates", __dir__)
 
-  def add_solid_errors_db_schema
+  def copy_files
     template "db/cable_schema.rb"
-  end
-
-  def configure_production_cable
-    gsub_file("config/cable.yml",
-              /production:\n(^\s*.*$\n){2,}/,
-              new_production_cable_config)
-  end
-
-  def configure_development_cable
-    gsub_file("config/cable.yml",
-              /development:\n\s*adapter: redis\n  url: .*\n/,
-              new_development_cable_config)
-  end
-
-  private
-
-  def new_production_cable_config
-    <<~YAML
-      production:
-        adapter: solid_cable
-        connects_to:
-          database:
-            writing: cable
-            reading: cable
-        polling_interval: 0.1.seconds
-        keep_messages_around_for: 1.day
-    YAML
-  end
-
-  def new_development_cable_config
-    <<~YAML
-      development:
-        adapter: solid_cable
-        connects_to:
-          database:
-            writing: cable
-            reading: cable
-        polling_interval: 1.second
-        keep_messages_around_for: 1.day
-        silence_polling: true
-    YAML
+    template "config/cable.yml", force: true
   end
 end

--- a/lib/generators/solid_cable/install/templates/config/cable.yml
+++ b/lib/generators/solid_cable/install/templates/config/cable.yml
@@ -1,0 +1,13 @@
+development:
+  adapter: async
+
+test:
+  adapter: test
+
+production:
+  adapter: solid_cable
+  connects_to:
+    database:
+      writing: cable
+  polling_interval: 0.1.seconds
+  keep_messages_around_for: 1.day


### PR DESCRIPTION
This too matches the rest of the Solid adapters. They're meant for production, not development.