### PR TITLE
Rename keep_messages_around_for to message_retention to pair with polling_interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ The options are:
 
 - `connects_to` - set the Active Record database configuration for the Solid Cable models. All options available in Active Record can be used here.
 - `polling_interval` - sets the frequency of the polling interval.
-- `keep_messages_around_for` - sets the retention time for messages kept in the database. Used as the cut-off when trimming is performed.
+- `message_retention` - sets the retention time for messages kept in the database. Used as the cut-off when trimming is performed.
 
 ## Trimming
 
 Currently, messages are kept around forever, and have to be manually pruned via the `SolidCable::PruneJob.perform_later` job.
-This job uses the `keep_messages_around_for` setting to determine how long messages are to be kept around.
+This job uses the `message_retention` setting to determine how long messages are to be kept around.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ Then run `db:prepare` in production to ensure the database is created and the sc
 
 By default messages are kept around forever. SolidCable ships with a job to
 prune messages. You can run `SolidCable::PruneJob.perform_later` which removes
-Messages that are older than what is specified in `keep_messages_around_for`
+Messages that are older than what is specified in `message_retention`
 setting.
 
 ## Configuration
 
-All configuration is managed via the `config/cable.yml`file. To use Solid Cable, the `adapter` value *must be* `solid_cable`. When using Solid Cable, the other values you can set are: `connects_to`, `polling_interval`, `silence_polling`, and `keep_messages_around_for`. For example:
+All configuration is managed via the `config/cable.yml`file. To use Solid Cable, the `adapter` value *must be* `solid_cable`. When using Solid Cable, the other values you can set are: `connects_to`, `polling_interval`, `silence_polling`, and `message_retention`. For example:
 
 ```yaml
 production:
@@ -79,7 +79,7 @@ production:
     database:
       writing: cable
   polling_interval: 0.1.seconds
-  keep_messages_around_for: 1.day
+  message_retention: 1.day
 ```
 
 ## License

--- a/app/models/solid_cable/message.rb
+++ b/app/models/solid_cable/message.rb
@@ -3,7 +3,7 @@
 module SolidCable
   class Message < SolidCable::Record
     scope :prunable, lambda {
-      where(created_at: ..::SolidCable.keep_messages_around_for.ago)
+      where(created_at: ..::SolidCable.message_retention.ago)
     }
     scope :broadcastable, lambda { |channels, last_id|
       where(channel: channels).where(id: (last_id + 1)..).order(:id)

--- a/bench/config/cable.yml
+++ b/bench/config/cable.yml
@@ -2,7 +2,7 @@ development:
   # adapter: redis
   # url: redis://localhost:6379/1
   adapter: solid_cable
-  keep_messages_around_for: 15.minutes
+  message_retention: 15.minutes
   polling_interval: 0.1.seconds
   connects_to:
     database:
@@ -18,5 +18,5 @@ production:
   # channel_prefix: cablebench_production
 
   adapter: solid_cable
-  keep_messages_around_for: ever
+  message_retention: ever
   polling_interval: 0.2.seconds

--- a/lib/generators/solid_cable/install/templates/config/cable.yml
+++ b/lib/generators/solid_cable/install/templates/config/cable.yml
@@ -10,4 +10,4 @@ production:
     database:
       writing: cable
   polling_interval: 0.1.seconds
-  keep_messages_around_for: 1.day
+  message_retention: 1.day

--- a/lib/solid_cable.rb
+++ b/lib/solid_cable.rb
@@ -18,8 +18,8 @@ module SolidCable
       parse_duration(cable_config.polling_interval, default: 0.1.seconds)
     end
 
-    def keep_messages_around_for
-      parse_duration(cable_config.keep_messages_around_for, default: 1.day)
+    def message_retention
+      parse_duration(cable_config.message_retention, default: 1.day)
     end
 
     private


### PR DESCRIPTION
Keeps parity in the config naming scheme.