### PR TITLE
force connection to configured database

### DIFF
--- a/app/models/solid_cable/record.rb
+++ b/app/models/solid_cable/record.rb
@@ -9,7 +9,8 @@ module SolidCable
     class << self
       def connection
         if SolidCable.connects_to.present?
-          connected_to(role: :writing) { super }
+          role = SolidCable.connects_to.dig(:database)&.keys&.first || :writing
+          connected_to(role: role) { super }
         else
           super
         end


### PR DESCRIPTION
This is a fix for #63, where table inspection queries were hitting postgres instead of the configured solid_cable database 

```
2025-05-13 11:57:50.043 EDT [13740] ERROR:  relation "solid_cable_messages" does not exist at character 523
2025-05-13 11:57:50.043 EDT [13740] STATEMENT:  SELECT a.attname, format_type(a.atttypid, a.atttypmod),
	       pg_get_expr(d.adbin, d.adrelid), a.attnotnull, a.atttypid, a.atttypmod,
	       c.collname, col_description(a.attrelid, a.attnum) AS comment,
	       attidentity AS identity,
	       attgenerated as attgenerated
	  FROM pg_attribute a
	  LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
	  LEFT JOIN pg_type t ON a.atttypid = t.oid
	  LEFT JOIN pg_collation c ON a.attcollation = c.oid AND a.attcollation <> t.typcollation
	 WHERE a.attrelid = '"solid_cable_messages"'::regclass
	   AND a.attnum > 0 AND NOT a.attisdropped
	 ORDER BY a.attnum
```