### PR TITLE
Eagerly initialize last_id to avoid skipping messages

### DIFF
--- a/lib/action_cable/subscription_adapter/solid_cable.rb
+++ b/lib/action_cable/subscription_adapter/solid_cable.rb
@@ -53,6 +53,7 @@ module ActionCable
             @critical = Concurrent::Semaphore.new(0)
 
             @reconnect_attempt = 0
+            @last_id = last_message_id
 
             @thread = Thread.new do
               Thread.current.name = "solid_cable_listener"
@@ -113,12 +114,7 @@ module ActionCable
 
           private
             attr_reader :event_loop, :thread
-            attr_writer :last_id
-            attr_accessor :reconnect_attempt
-
-            def last_id
-              @last_id ||= last_message_id
-            end
+            attr_accessor :last_id, :reconnect_attempt
 
             def last_message_id
               ::SolidCable::Message.maximum(:id) || 0

--- a/test/lib/action_cable/subscription_adapter/solid_cable_test.rb
+++ b/test/lib/action_cable/subscription_adapter/solid_cable_test.rb
@@ -175,30 +175,6 @@ class ActionCable::SubscriptionAdapter::SolidCableTest < ActionCable::TestCase
     end
   end
 
-  10.times do |i|
-    test "#broadcast immediately after #subscribe does not skip messages - iteration #{i}" do
-      subscribed = Concurrent::Event.new
-      message_received = Concurrent::Event.new
-      message = nil
-
-      subscription_callback = -> { subscribed.set }
-      message_callback = ->(msg) {
-        message = msg
-        message_received.set
-      }
-
-      @rx_adapter.subscribe("channel", message_callback, subscription_callback)
-      assert subscribed.wait(WAIT_WHEN_EXPECTING_EVENT),
-        "Timed out waiting for subscription"
-
-      @tx_adapter.broadcast("channel", "don't skip me")
-      assert message_received.wait(WAIT_WHEN_EXPECTING_EVENT), "Message skipped"
-      assert_equal "don't skip me", message
-    ensure
-      @rx_adapter.unsubscribe("channel", message_callback)
-    end
-  end
-
   test "retries after a connection failure and keeps listening" do
     with_cable_config reconnect_attempts: [0] do
       raised = false

--- a/test/lib/action_cable/subscription_adapter/solid_cable_test.rb
+++ b/test/lib/action_cable/subscription_adapter/solid_cable_test.rb
@@ -175,6 +175,30 @@ class ActionCable::SubscriptionAdapter::SolidCableTest < ActionCable::TestCase
     end
   end
 
+  10.times do |i|
+    test "#broadcast immediately after #subscribe does not skip messages - iteration #{i}" do
+      subscribed = Concurrent::Event.new
+      message_received = Concurrent::Event.new
+      message = nil
+
+      subscription_callback = -> { subscribed.set }
+      message_callback = ->(msg) {
+        message = msg
+        message_received.set
+      }
+
+      @rx_adapter.subscribe("channel", message_callback, subscription_callback)
+      assert subscribed.wait(WAIT_WHEN_EXPECTING_EVENT),
+        "Timed out waiting for subscription"
+
+      @tx_adapter.broadcast("channel", "don't skip me")
+      assert message_received.wait(WAIT_WHEN_EXPECTING_EVENT), "Message skipped"
+      assert_equal "don't skip me", message
+    ensure
+      @rx_adapter.unsubscribe("channel", message_callback)
+    end
+  end
+
   test "retries after a connection failure and keeps listening" do
     with_cable_config reconnect_attempts: [0] do
       raised = false
@@ -212,7 +236,6 @@ class ActionCable::SubscriptionAdapter::SolidCableTest < ActionCable::TestCase
       subscribed = Concurrent::Event.new
       adapter.subscribe(channel, callback, proc { subscribed.set })
       subscribed.wait(WAIT_WHEN_EXPECTING_EVENT)
-      sleep WAIT_WHEN_EXPECTING_EVENT
       assert_predicate subscribed, :set?
 
       yield queue


### PR DESCRIPTION
**What does this do?**

This change eagerly initializes `@last_id` to avoid skipping messages.

**Why?**

Currently, `@last_id` is lazily initialized as `MAX(id)` on the listener thread's first call to `broadcast_messages`.

https://github.com/rails/solid_cable/blob/af986787675368cc3addf6b5c9f584d56c26ccc1/lib/action_cable/subscription_adapter/solid_cable.rb#L119-L121

However, if a broadcast inserts a message _between_ a subscription _and_ that first call, `MAX(id)` returns a value that includes that inserted message message, causing the query `WHERE id > last_id` to miss it entirely.

For example:

```
Main thread                           Listener thread
──────────                            ───────────────
subscribe()
  Listener.new → starts thread →      thread starts, enters listen loop
  add_channel:
    channels["test"] = MAX(id) = 5
    event_loop.post(on_success)
                                      interruptible { executor.run! }
on_success fires → subscribed.set
subscribed.wait returns
                                      ↑ still hasn't reached broadcast_messages
broadcast("hello") → inserts id=6
                                      broadcast_messages:
                                        @last_id ||= MAX(id) → 6  ← INCLUDES THE MESSAGE
                                        broadcastable(["test"], 6)
                                          → WHERE id > 6 → nothing returned!
                                        message 6 is SKIPPED
```

The per-channel cursor (`channels["test"] = 5`) doesn't help, because it's only checked as a secondary filter inside the loop over query results, which already excluded the message.

https://github.com/rails/solid_cable/blob/af986787675368cc3addf6b5c9f584d56c26ccc1/lib/action_cable/subscription_adapter/solid_cable.rb#L134-L148

**How to repro?**

This is evident in the existing test suite, where `sleep` is required after the first `subscribe` to give the listener thread time to complete the first poll cycle and evaluate `@last_id` to a pre-broadcast max. 

https://github.com/rails/solid_cable/blob/af986787675368cc3addf6b5c9f584d56c26ccc1/test/lib/action_cable/subscription_adapter/solid_cable_test.rb#L215

Removing this `sleep` causes tests to fail without this change.

**What do I NOT like about this change?**

There is now a DB read in the constructor... Though:

- Listeners are already lazily initialized so this is not a boot-time issue
- DB connection is ready: both the listener thread & `#subscribe` call perform DB read/writes immediately

---

Thanks and open to suggestions!