### PR TITLE
Use the channel hash directly instead of rehashing every poll

### DIFF
--- a/app/models/solid_cable/message.rb
+++ b/app/models/solid_cable/message.rb
@@ -5,19 +5,14 @@ module SolidCable
     scope :trimmable, lambda {
       where(created_at: ...::SolidCable.message_retention.ago)
     }
-    scope :broadcastable, lambda { |channels, last_id|
-      where(channel_hash: channel_hashes_for(channels)).
-        where(id: (last_id.to_i + 1)..).order(:id)
+    scope :broadcastable, lambda { |channel_hashes, last_id|
+      where(channel_hash: channel_hashes).where(id: (last_id.to_i + 1)..).order(:id)
     }
 
     class << self
       def broadcast(channel, payload)
         insert({ created_at: Time.current, channel:, payload:,
           channel_hash: channel_hash_for(channel) })
-      end
-
-      def channel_hashes_for(channels)
-        channels.map { |channel| channel_hash_for(channel) }
       end
 
       # Need to unpack this as a signed integer since Postgresql and SQLite

--- a/lib/action_cable/subscription_adapter/solid_cable.rb
+++ b/lib/action_cable/subscription_adapter/solid_cable.rb
@@ -122,12 +122,12 @@ module ActionCable
           end
 
           def add_channel(channel, on_success)
-            channels[channel] = last_message_id
+            channels[::SolidCable::Message.channel_hash_for(channel)] = last_message_id
             on_success.call if on_success
           end
 
           def remove_channel(channel)
-            channels.delete(channel)
+            channels.delete(::SolidCable::Message.channel_hash_for(channel))
           end
 
           def invoke_callback(*)
@@ -151,17 +151,17 @@ module ActionCable
 
               ::SolidCable::Message.
                 broadcastable(current_channels.keys, last_id).
-                each do |message|
+                pluck(:id, :channel, :channel_hash, :payload).each do |id, channel, channel_hash, payload|
                   should_broadcast_message = false
-                  channels.compute_if_present(message.channel) do |channel_last_id|
-                    break if channel_last_id >= message.id
+                  channels.compute_if_present(channel_hash) do |channel_last_id|
+                    break if channel_last_id >= id
 
                     should_broadcast_message = true
-                    message.id
+                    id
                   end
 
-                  broadcast(message.channel, message.payload) if should_broadcast_message
-                  self.last_id = message.id
+                  broadcast(channel, payload) if should_broadcast_message
+                  self.last_id = id
                 end
 
               self.reconnect_attempt = 0


### PR DESCRIPTION
For every poll we were re-hashing every channel name to look up the messages which is wasteful. Instead store in the hash of watching channels the hashed channel  so each pool we can just pass it off directly to the query without any hashing.